### PR TITLE
Allow excluding current session when switching sessions

### DIFF
--- a/easysession.el
+++ b/easysession.el
@@ -564,7 +564,8 @@ OVERWRITE-ALIST is an alist similar to
     result))
 
 (defun easysession--get-all-names (&optional exclude-current)
-  "Return a list of all session names."
+  "Return a list of all session names.
+If EXCLUDE-CURRENT is non-nil, exclude the current session name from the list."
   (if (file-directory-p easysession-directory)
       (seq-filter (lambda (session-name)
                     (not (or (string-equal session-name ".")
@@ -577,7 +578,9 @@ OVERWRITE-ALIST is an alist similar to
 
 (defun easysession--prompt-session-name (prompt &optional session-name exclude-current)
   "Prompt for a session name with PROMPT.
-Use SESSION-NAME as the default value."
+Use SESSION-NAME as the default value.
+If EXCLUDE-CURRENT is non-nil, exclude the current session from
+completion candidates."
   (completing-read (concat "[easysession] " prompt)
                    (easysession--get-all-names exclude-current)
                    nil nil nil nil session-name))


### PR DESCRIPTION
This PR adds a new customization option, **easysession-switch-to-exclude-current**, which defaults to nil (to preserve the old behavior by default).

When non-nil, the current session is filtered out from the list of completion candidates offered by **easysession-switch-to**.

Motivation:
Enabling this option improves the user experience when using a completion UI like Vertico. When toggling between two main sessions, the other session becomes the first candidate, allowing the user to switch with just RET instead of needing to move past the current session first.

---

Thanks for considering this contribution and thanks a lot for your work on the package!