### PR TITLE
Fix `easysession-save-as` sexp and make rename session add session name to the prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ![License](https://img.shields.io/github/license/jamescherti/easysession.el)
 ![](https://raw.githubusercontent.com/jamescherti/easysession.el/main/.images/made-for-gnu-emacs.svg)
 
-The `easysession.el` Emacs package is a session manager for Emacs that can persist and restore file editing buffers, indirect buffers/clones, Dired buffers, windows/splits, the built-in tab-bar (including tabs, their buffers, and windows), and Emacs frames. It offers a convenient and effortless way to manage Emacs editing sessions and utilizes built-in Emacs functions to persist and restore frames.
+The **easysession** Emacs package is a session manager for Emacs that can persist and restore file editing buffers, indirect buffers/clones, Dired buffers, windows/splits, the built-in tab-bar (including tabs, their buffers, and windows), and Emacs frames. It offers a convenient and effortless way to manage Emacs editing sessions and utilizes built-in Emacs functions to persist and restore frames.
 
 <!-- markdown-toc start - Don't edit this section. Run M-x markdown-toc-refresh-toc -->
 ## Table of Contents
@@ -50,11 +50,11 @@ Key features include:
 
 ## Installation
 
-To install `easysession` from MELPA:
+To install **easysession** from MELPA:
 
 1. If you haven't already done so, [add MELPA repository to your Emacs configuration](https://melpa.org/#/getting-started).
 
-2. Add the following code to your Emacs init file to install `easysession` from MELPA:
+2. Add the following code to your Emacs init file to install **easysession** from MELPA:
 
 ``` emacs-lisp
 (use-package easysession
@@ -142,7 +142,7 @@ To persist and restore global variables in Emacs, you can use the built-in `save
 
 (Each element added to `savehist-additional-variables` is a variable that will be persisted across Emacs sessions that use `savehist`.)
 
-The `easysession` package can leverage `savehist` save the restore the current session name:
+The **easysession** package can leverage `savehist` save the restore the current session name:
 ```emacs-lisp
 (add-to-list 'savehist-additional-variables 'easysession--current-session-name)
 ```
@@ -282,18 +282,18 @@ Replace `TODO` with the appropriate code and remove `[MY EASYSESSION TEST]` afte
 
 ### How does the author use easysession?
 
-The author uses `easysession.el` by setting up each session to represent a distinct project or a specific "view" on a particular project, including various tabs (built-in tab-bar), window splits, dired buffers, and file editing buffers. This organization allows for the creation of dedicated environments for different tasks or aspects of a project, such as development, debugging, specific issue, and documentation. The author switches between projects and views of the same projects multiple times a day, and `easysession.el` helps significantly by allowing quick transitions between them.
+The author uses easysession by setting up each session to represent a distinct project or a specific "view" on a particular project, including various tabs (built-in tab-bar), window splits, dired buffers, and file editing buffers. This organization allows for the creation of dedicated environments for different tasks or aspects of a project, such as development, debugging, specific issue, and documentation. The author switches between projects and views of the same projects multiple times a day, and easysession helps significantly by allowing quick transitions between them.
 
 ### What does EasySession offer that desktop.el doesn't?
 
 While `desktop.el` is a foundational session management tool for Emacs, it has several limitations:
 - It primarily saves Emacs' state on exit and restores it on startup, making it difficult to switch between different session files during an editing session.
-- The `desktop.el` package does not allow the user to easily choose whether to load sessions with or without modifying the Emacs frame geometry. This last feature is important in easysession.el because it allows switching between sessions without the annoyance of changing the window position or size.
+- The `desktop.el` package does not allow the user to easily choose whether to load sessions with or without modifying the Emacs frame geometry. This last feature is important in easysession because it allows switching between sessions without the annoyance of changing the window position or size.
 - The `desktop.el` package saves and restores major modes and important global variables, which can prevent some packages from initializing correctly. For example, the `vdiff` package may stop working after comparing two files and reloading Emacs and the `desktop.el` session. This issue has also occurred with a few other packages.
 - The `desktop.el` package can be bulky and slow in operation.
 - The `desktop.el` package lacks support for saving and restoring indirect buffers (clones). Indirect buffers are secondary buffers that share the same content as an existing buffer but can have different point positions, narrowing, folds, and other buffer-local settings. This allows users to view and edit the same file or text content in multiple ways simultaneously without duplicating the actual data. There are third-party packages, such as desktop+, that extend desktop.el to restore indirect buffers. However, packages like desktop+ are still based on desktop.el and can cause the issues described above.
 
-In contrast, `easysession.el` offers enhanced functionality:
+In contrast, easysession offers enhanced functionality:
 - It supports saving and loading various buffer types, including indirect buffers (clones).
 - It allows users to load or save different sessions while actively editing, without the need to restart Emacs.
 - It excels in speed and efficiency, enabling seamless session management within Emacs.
@@ -316,7 +316,7 @@ There are some existing packages, such as minimal-session-saver, save-visited-fi
 - None of them can restore indirect buffers (clones). Indirect buffers, which can be created using `clone-indirect-buffer`, are secondary buffers that share the same content as an existing buffer but can have different point positions, narrowing, folds, and other buffer-local settings. This allows users to view and edit the same file or text content in multiple ways simultaneously without duplicating the actual data.
 - The minimal-session-saver and save-visited-files packages are no longer maintained and cannot restore the frameset and the tab-bar.
 - Sesman is designed to implement some IDE features in Emacs.
-- Psession cannot switch between sessions quickly, with or without modifying the the Emacs frame geometry. This last feature is important in easysession.el because it allows switching between sessions without the annoyance of changing the window position or size.
+- Psession cannot switch between sessions quickly, with or without modifying the the Emacs frame geometry. This last feature is important in easysession because it allows switching between sessions without the annoyance of changing the window position or size.
 
 Easysession can persist and restore file editing buffers, indirect buffers/clones, Dired buffers, the tab-bar, and the Emacs frames (with or without the Emacs frames geometry). It is similar to Vim or Neovim sessions because it loads and restores your editing environment, including buffers, windows, tabs, and other settings, allowing you to resume work exactly where you left off.
 
@@ -328,7 +328,7 @@ Easysession can persist and restore file editing buffers, indirect buffers/clone
 
 ## License
 
-The `easysession` Emacs package has been written by [James Cherti](https://www.jamescherti.com/) and is distributed under terms of the GNU General Public License version 3, or, at your choice, any later version.
+The easysession Emacs package has been written by [James Cherti](https://www.jamescherti.com/) and is distributed under terms of the GNU General Public License version 3, or, at your choice, any later version.
 
 Copyright (C) 2024-2025 [James Cherti](https://www.jamescherti.com)
 

--- a/easysession.el
+++ b/easysession.el
@@ -580,14 +580,16 @@ If EXCLUDE-CURRENT is non-nil, exclude the current session name from the list."
                   (directory-files easysession-directory nil nil t))
     '()))
 
-(defun easysession--prompt-session-name (prompt &optional session-name exclude-current)
+(defun easysession--prompt-session-name (prompt &optional session-name
+                                                exclude-current initial-input)
   "Prompt for a session name with PROMPT.
 Use SESSION-NAME as the default value.
 If EXCLUDE-CURRENT is non-nil, exclude the current session from
+If INITIAL-INPUT is non-nil, insert it in the minibuffer initially.
 completion candidates."
   (completing-read (concat "[easysession] " prompt)
                    (easysession--get-all-names exclude-current)
-                   nil nil nil nil session-name))
+                   nil nil initial-input nil session-name))
 
 (defun easysession--get-base-buffer-info (buffer)
   "Get the name and path of the buffer BUFFER.
@@ -935,7 +937,10 @@ non-nil, the current session is saved."
   "Rename the current session to NEW-SESSION-NAME."
   (interactive (list (easysession--prompt-session-name
                       (format "Rename session '%s' to: "
-                              (easysession-get-session-name)))))
+                              (easysession-get-session-name))
+                      nil
+                      nil
+                      (easysession-get-session-name))))
   (unless new-session-name
     (error (concat "[easysession] easysession-rename: You need to specify"
                    "the new session name.")))

--- a/easysession.el
+++ b/easysession.el
@@ -948,13 +948,10 @@ non-nil, the current session is saved."
     (setq easysession--current-session-name new-session-name)))
 
 ;;;###autoload
-(defun easysession-delete (&optional session-name)
+(defun easysession-delete (session-name)
   "Delete a session. Prompt for SESSION-NAME if not provided."
-  (interactive)
-  (let* ((session-name (or session-name
-                           (easysession--prompt-session-name
-                            "Delete session: " session-name)))
-         (session-file (easysession--exists session-name)))
+  (interactive (list (easysession--prompt-session-name "Delete session: ")))
+  (let* ((session-file (easysession--exists session-name)))
     (if session-file
         (progn
           (let ((session-buffer (find-buffer-visiting session-file)))
@@ -1122,10 +1119,10 @@ SESSION-NAME is the name of the session."
     (run-hooks 'easysession-after-save-hook)))
 
 ;;;###autoload
-(defun easysession-save-as (&optional session-name)
-  "Save the state of all frames into a session with the given name.
-If SESSION-NAME is provided, use it; otherwise, use current session.
-If the function is called interactively, ask the user."
+(defun easysession-save-as (session-name)
+  "Save the session as SESSION-NAME and make it the current session.
+
+If the function is called interactively, prompt the user for a session name."
   (interactive
    (easysession--prompt-session-name "Save session as: "
                                      (easysession-get-session-name)))
@@ -1141,24 +1138,23 @@ If the function is called interactively, ask the user."
     t))
 
 ;;;###autoload
-(defun easysession-switch-to (&optional session-name)
-  "Save the current session and load a new one.
+(defun easysession-switch-to (session-name)
+  "Save the current session and load SESSION-NAME.
 
-This function handles saving the current session and loading a new session
-specified by SESSION-NAME. If SESSION-NAME is not provided, it will prompt the
-user for a session name if called interactively. If the session already exists,
-it will be loaded; otherwise, a new session will be created.
+This function saves the current Emacs session and loads the session specified by
+SESSION-NAME. If SESSION-NAME is not provided, it prompts the user for a session
+name when called interactively.
 
-SESSION-NAME is the name of the session to switch to. If nil, the function
-prompts the user for a session name if called interactively.
-
-Behavior:
-- If the current session is loaded and not being reloaded, the current session
-is saved.
-- Loads the specified session.
-- Sets the specified session as the current session.
+This function will:
+- Save the current session if it is loaded and not being reloaded.
+- Load the specified session.
+- Set the specified session as the current session.
 - If the session does not exist, it is saved and an empty session is
-initialized."
+  initialized.
+
+If the session is already loaded, a message is displayed to indicate it has been
+reloaded. If the session is newly created or switched to, a message is displayed
+accordingly."
   (interactive
    (list (easysession--prompt-session-name
           "Load and switch to session: "

--- a/easysession.el
+++ b/easysession.el
@@ -1124,8 +1124,8 @@ SESSION-NAME is the name of the session."
 
 If the function is called interactively, prompt the user for a session name."
   (interactive
-   (easysession--prompt-session-name "Save session as: "
-                                     (easysession-get-session-name)))
+   (list (easysession--prompt-session-name "Save session as: "
+                                           (easysession-get-session-name))))
   (let* ((new-session-name (or session-name (easysession-get-session-name)))
          (previous-session-name easysession--current-session-name))
     (easysession--ensure-session-name-valid new-session-name)


### PR DESCRIPTION
Fix `easysession-save-as` (interactive) S-expression and rename the function.  
The rename session function prompts now use the current session name.