### PR TITLE
Fix frameset restore hooks and side-window persistence

### DIFF
--- a/easysession.el
+++ b/easysession.el
@@ -1236,6 +1236,34 @@ when no frames are available for persistence."
                  (not (frame-parameter nil 'client))))
        t))
 
+(defun easysession--call-with-default-buffer-list-update-hook (hook function)
+  "Call FUNCTION with the default `buffer-list-update-hook' set to HOOK.
+
+The dynamic binding is established in a buffer without a buffer-local hook
+value.  This ensures that it applies to the default value even when the
+caller's current buffer has its own value.  FUNCTION may change the current
+buffer; its final current buffer is retained."
+  (let* ((original-buffer (current-buffer))
+         (binding-buffer
+          (seq-find
+           (lambda (buffer)
+             (not (local-variable-p 'buffer-list-update-hook buffer)))
+           (buffer-list)))
+         temporary-buffer)
+    (unless binding-buffer
+      (setq temporary-buffer
+            (let ((buffer-list-update-hook nil))
+              (generate-new-buffer " *easysession-hook-binding*"))
+            binding-buffer temporary-buffer))
+    (set-buffer binding-buffer)
+    (let ((buffer-list-update-hook hook))
+      (set-buffer original-buffer)
+      (unwind-protect
+          (funcall function)
+        (when (buffer-live-p temporary-buffer)
+          (ignore-errors
+            (kill-buffer temporary-buffer)))))))
+
 (defun easysession--load-frameset (session-data &optional load-geometry)
   "Load the frameset from the SESSION-DATA argument.
 When LOAD-GEOMETRY is non-nil, load the frame geometry."
@@ -1257,32 +1285,68 @@ When LOAD-GEOMETRY is non-nil, load the frame geometry."
         (setq data (when (assoc "frameset" session-data)
                      (assoc-default "frameset" session-data))))
       (when data
-        (frameset-restore
-         data
-         :filters modified-filter-alist
-         :reuse-frames easysession-frameset-restore-reuse-frames
-         :cleanup-frames
-         (if (eq easysession-frameset-restore-cleanup-frames t)
-             (lambda (frame action)
-               (when (and (memq action '(:rejected :ignored))
-                          ;; Avoid cleaning up the initial daemon frame during
-                          ;; frameset restoration by disabling frame cleanup
-                          ;; when running under a daemon with a single frame.
-                          (not (and (daemonp)
-                                    (equal (terminal-name (frame-terminal frame))
-                                           "initial_terminal"))))
-                 (delete-frame frame)))
-           easysession-frameset-restore-cleanup-frames)
-         :force-display easysession-frameset-restore-force-display
-         :force-onscreen easysession-frameset-restore-force-onscreen)
+        ;; `display-buffer-in-side-window' normally makes these parameters
+        ;; persistent when it creates a side window.  `frameset-restore'
+        ;; reconstructs their values without that registration, so restore it
+        ;; here to keep the next session save from dropping the side layout.
+        (setf (alist-get 'window-side window-persistent-parameters) 'writable
+              (alist-get 'window-slot window-persistent-parameters) 'writable)
 
-        (when (fboundp 'tab-bar-mode)
-          (when (seq-some
-                 (lambda (frame)
-                   (menu-bar-positive-p
-                    (frame-parameter frame 'tab-bar-lines)))
-                 (frame-list))
-            (tab-bar-mode 1)))))))
+        (let ((buffer-list-update-pending nil)
+              (frameset-restored nil)
+              (original-buffer-list-update-hook
+               (default-value 'buffer-list-update-hook)))
+          ;; Restoring a frameset temporarily selects buffers while rebuilding
+          ;; the saved layout.  Coalesce notifications dispatched through the
+          ;; default hook value into one update after restoration reaches its
+          ;; final state.  Buffer-local hook values retain their normal
+          ;; semantics.
+          (unwind-protect
+              (easysession--call-with-default-buffer-list-update-hook
+               (list (lambda ()
+                       (setq buffer-list-update-pending t)))
+               (lambda ()
+                 (frameset-restore
+                  data
+                  :filters modified-filter-alist
+                  :reuse-frames easysession-frameset-restore-reuse-frames
+                  :cleanup-frames
+                  (if (eq easysession-frameset-restore-cleanup-frames t)
+                      (lambda (frame action)
+                        (when (and (memq action '(:rejected :ignored))
+                                   ;; Avoid cleaning up the initial daemon
+                                   ;; frame during frameset restoration by
+                                   ;; disabling frame cleanup when running
+                                   ;; under a daemon with a single frame.
+                                   (not (and
+                                         (daemonp)
+                                         (equal
+                                          (terminal-name
+                                           (frame-terminal frame))
+                                          "initial_terminal"))))
+                          (delete-frame frame)))
+                    easysession-frameset-restore-cleanup-frames)
+                  :force-display easysession-frameset-restore-force-display
+                  :force-onscreen easysession-frameset-restore-force-onscreen)
+
+                 (when (fboundp 'tab-bar-mode)
+                   (when (seq-some
+                          (lambda (frame)
+                            (menu-bar-positive-p
+                             (frame-parameter frame 'tab-bar-lines)))
+                          (frame-list))
+                     (tab-bar-mode 1)))
+
+                 (setq frameset-restored t)))
+            (when buffer-list-update-pending
+              (let ((buffer-list-update-hook
+                     original-buffer-list-update-hook))
+                (if frameset-restored
+                    (run-hooks 'buffer-list-update-hook)
+                  ;; Preserve the original frameset error if an observer also
+                  ;; fails while synchronizing with the partial restored state.
+                  (ignore-errors
+                    (run-hooks 'buffer-list-update-hook)))))))))))
 
 (defun easysession--ensure-buffer-name (buffer name)
   "Ensure that BUFFER name is NAME."

--- a/tests/test-easysession.el
+++ b/tests/test-easysession.el
@@ -69,6 +69,18 @@
 (defvar test-easysession--indirect-buffer1 nil
   "Reference to the indirect test buffer.")
 
+(defun test-easysession--tree-contains-p (tree value)
+  "Return non-nil when TREE contains VALUE as a subtree."
+  (cond
+   ((equal tree value) t)
+   ((consp tree)
+    (or (test-easysession--tree-contains-p (car tree) value)
+        (test-easysession--tree-contains-p (cdr tree) value)))
+   ((vectorp tree)
+    (seq-some (lambda (item)
+                (test-easysession--tree-contains-p item value))
+              tree))))
+
 (defun test-easysession--add-hooks ()
   "Add and configure hooks for testing `easysession`.
 Tracks the execution of session-related hooks and performs checks
@@ -308,6 +320,223 @@ storing them in respective variables for later use."
     (error (concat "easysession--auto-save or the "
                    "easysession-save-mode-predicate do not seem to "
                    "be working"))))
+
+(ert-deftest test-easysession-load-coalesces-buffer-list-update-hook ()
+  "Default buffer list observers see only the final restored frameset."
+  (let* ((temporary-directory (make-temp-file "easysession-test-" t))
+         (easysession-directory (file-name-as-directory temporary-directory))
+         (easysession--builtin-load-handlers nil)
+         (easysession--load-handlers nil)
+         (easysession--current-session-name nil)
+         (easysession--session-loaded nil)
+         (easysession-enable-frameset-restore t)
+         (easysession-fontify nil)
+         (before-load-hook-called nil)
+         (after-load-hook-called nil)
+         (restore-running nil)
+         (restore-finished nil)
+         (hook-calls-during-restore 0)
+         (hook-calls-after-restore 0)
+         (hook-calls-outside-load 0)
+         (local-hook-calls 0)
+         stable-hook-buffer
+         (first-buffer (generate-new-buffer " *easysession-first*"))
+         (second-buffer (generate-new-buffer " *easysession-second*"))
+         (easysession-before-load-hook
+          (list (lambda () (setq before-load-hook-called t))))
+         (easysession-after-load-hook
+          (list (lambda () (setq after-load-hook-called t))))
+         (buffer-list-update-hook
+          (list (lambda ()
+                  (cond
+                   (restore-running
+                    (setq hook-calls-during-restore
+                          (1+ hook-calls-during-restore)))
+                   (restore-finished
+                    (if easysession-load-in-progress
+                        (setq hook-calls-after-restore
+                              (1+ hook-calls-after-restore)
+                              stable-hook-buffer (current-buffer))
+                      (setq hook-calls-outside-load
+                            (1+ hook-calls-outside-load))))
+                   (t
+                    (setq hook-calls-outside-load
+                          (1+ hook-calls-outside-load))))))))
+    (unwind-protect
+        (save-window-excursion
+          (delete-other-windows)
+          (switch-to-buffer first-buffer)
+          (let ((source-window (selected-window))
+                (restored-window (split-window-right)))
+            (set-window-buffer restored-window second-buffer)
+            (dolist (buffer (list first-buffer second-buffer))
+              (with-current-buffer buffer
+                (setq-local
+                 buffer-list-update-hook
+                 (list (lambda ()
+                         (setq local-hook-calls (1+ local-hook-calls)))
+                       t))))
+            (with-temp-file
+                (expand-file-name "hook-test" easysession-directory)
+              (prin1 '(("frameset" . test-frameset)) (current-buffer)))
+            (cl-letf (((symbol-function 'frameset-restore)
+                       (lambda (&rest _)
+                         (setq restore-running t)
+                         (select-window restored-window)
+                         (select-window source-window)
+                         (select-window restored-window)
+                         (setq restore-running nil
+                               restore-finished t))))
+              (easysession-load "hook-test")))
+
+          (should before-load-hook-called)
+          (should after-load-hook-called)
+          (should (= hook-calls-during-restore 0))
+          (should (= hook-calls-after-restore 1))
+          ;; Buffer-local hook values retain their normal semantics, including
+          ;; their `t' element that continues with the default hook value.
+          (should (= local-hook-calls 3))
+          (should (eq stable-hook-buffer second-buffer))
+          (let ((outside-calls hook-calls-outside-load))
+            (run-hooks 'buffer-list-update-hook)
+            (should (= hook-calls-outside-load (1+ outside-calls)))
+            (should (= local-hook-calls 4)))
+
+          ;; Do not invent a notification when frameset restoration made no
+          ;; buffer-list change.
+          (setq restore-finished nil
+                hook-calls-after-restore 0
+                stable-hook-buffer nil)
+          (cl-letf (((symbol-function 'frameset-restore)
+                     (lambda (&rest _)
+                       (setq restore-finished t))))
+            (easysession-load "hook-test"))
+          (should (= hook-calls-after-restore 0))
+          (should (= local-hook-calls 4)))
+      (when (buffer-live-p first-buffer)
+        (kill-buffer first-buffer))
+      (when (buffer-live-p second-buffer)
+        (kill-buffer second-buffer))
+      (delete-directory temporary-directory t))))
+
+(ert-deftest test-easysession-load-restores-hook-after-frameset-error ()
+  "A failed frameset restore replays and restores the default hook safely."
+  (let* ((temporary-directory (make-temp-file "easysession-test-" t))
+         (easysession-directory (file-name-as-directory temporary-directory))
+         (easysession--builtin-load-handlers nil)
+         (easysession--load-handlers nil)
+         (easysession--current-session-name nil)
+         (easysession--session-loaded nil)
+         (easysession-enable-frameset-restore t)
+         (easysession-fontify nil)
+         (easysession-before-load-hook nil)
+         (easysession-after-load-hook nil)
+         (restore-running nil)
+         (hook-calls-during-restore 0)
+         (hook-calls-after-error 0)
+         (hook-calls-outside-load 0)
+         (observer-error-enabled t)
+         (first-buffer (generate-new-buffer " *easysession-error-first*"))
+         (second-buffer (generate-new-buffer " *easysession-error-second*"))
+         (buffer-list-update-hook
+          (list (lambda ()
+                  (if restore-running
+                      (setq hook-calls-during-restore
+                            (1+ hook-calls-during-restore))
+                    (if easysession-load-in-progress
+                        (setq hook-calls-after-error
+                              (1+ hook-calls-after-error))
+                      (setq hook-calls-outside-load
+                            (1+ hook-calls-outside-load)))))
+                (lambda ()
+                  (when (and observer-error-enabled
+                             easysession-load-in-progress)
+                    (error "synthetic observer failure"))))))
+    (unwind-protect
+        (save-window-excursion
+          (delete-other-windows)
+          (switch-to-buffer first-buffer)
+          (let ((restored-window (split-window-right)))
+            (set-window-buffer restored-window second-buffer)
+            (with-temp-file
+                (expand-file-name "hook-error-test" easysession-directory)
+              (prin1 '(("frameset" . test-frameset)) (current-buffer)))
+            (cl-letf (((symbol-function 'frameset-restore)
+                       (lambda (&rest _)
+                         (setq restore-running t)
+                         (select-window restored-window)
+                         (setq restore-running nil)
+                         (error "synthetic frameset failure"))))
+              (let ((error-data
+                     (should-error
+                      (easysession-load "hook-error-test")
+                      :type 'error)))
+                (should
+                 (string-match-p "synthetic frameset failure"
+                                 (error-message-string error-data)))
+                (should-not
+                 (string-match-p "synthetic observer failure"
+                                 (error-message-string error-data))))))
+
+          (should (= hook-calls-during-restore 0))
+          (should (= hook-calls-after-error 1))
+          (should-not easysession-load-in-progress)
+          (setq observer-error-enabled nil)
+          (let ((outside-calls hook-calls-outside-load))
+            (run-hooks 'buffer-list-update-hook)
+            (should (= hook-calls-outside-load (1+ outside-calls)))))
+      (setq observer-error-enabled nil)
+      (when (buffer-live-p first-buffer)
+        (kill-buffer first-buffer))
+      (when (buffer-live-p second-buffer)
+        (kill-buffer second-buffer))
+      (delete-directory temporary-directory t))))
+
+(ert-deftest test-easysession-load-keeps-side-window-parameters-persistent ()
+  "A restored side window remains serializable by the next session save."
+  (let* ((temporary-directory (make-temp-file "easysession-test-" t))
+         (easysession-directory (file-name-as-directory temporary-directory))
+         (easysession--builtin-load-handlers nil)
+         (easysession--load-handlers nil)
+         (easysession--current-session-name nil)
+         (easysession--session-loaded nil)
+         (easysession-before-load-hook nil)
+         (easysession-after-load-hook nil)
+         (easysession-enable-frameset-restore t)
+         (easysession-fontify nil)
+         (window-persistent-parameters
+          (assq-delete-all
+           'window-side
+           (assq-delete-all 'window-slot
+                            (copy-tree window-persistent-parameters))))
+         frameset-restored)
+    (unwind-protect
+        (progn
+          (with-temp-file (expand-file-name "side-window-test"
+                                            easysession-directory)
+            (prin1 '(("frameset" . test-frameset)) (current-buffer)))
+          (cl-letf (((symbol-function 'frameset-restore)
+                     (lambda (&rest _)
+                       (setq frameset-restored t))))
+            (easysession-load "side-window-test"))
+
+          (should frameset-restored)
+          (let ((window (selected-window)))
+            (unwind-protect
+                (progn
+                  (set-window-parameter window 'window-side 'right)
+                  (set-window-parameter window 'window-slot 0)
+                  (let ((next-frameset
+                         (easysession--save-frameset "next-session")))
+                    (should
+                     (test-easysession--tree-contains-p
+                      next-frameset '(window-side . right)))
+                    (should
+                     (test-easysession--tree-contains-p
+                      next-frameset '(window-slot . 0)))))
+              (set-window-parameter window 'window-side nil)
+              (set-window-parameter window 'window-slot nil))))
+      (delete-directory temporary-directory t))))
 
 (defun test-easysession--init ()
   "Init test."


### PR DESCRIPTION
## Summary

- Coalesce notifications from the default `buffer-list-update-hook` while a
  frameset is being restored, then replay the original default hook once on the
  final restored state.
- Register `window-side` and `window-slot` as writable persistent parameters
  before restoration so a restore-then-save cycle keeps side-window identity.

## Problem

`frameset-restore` temporarily selects several buffers and windows while it
rebuilds a layout.  Default/global buffer-list observers therefore see partial
states and may repeatedly perform expensive synchronous work.  In a downstream
macOS Emacs setup, that path could re-enter the native event loop often enough
to trigger a native crash during startup.

There is a separate persistence issue for side windows: creating a side window
normally registers `window-side` and `window-slot` as writable, but restoring
their values does not restore that registration.  The next frameset save can
therefore silently drop both parameters.

## Behavior

The default hook value is dynamically rebound only in the restoring thread.
Buffer-local hook values retain their normal Emacs semantics.  If the default
hook receives any notification during restoration and tab-bar finalization,
the original default value runs once with the final selected buffer.

The binding is restored with `unwind-protect`.  If frameset restoration fails,
a pending notification is still replayed, while an observer failure is kept
from masking the original restore error.

## Verification

- The three added regression tests fail against current `main` and pass with
  this change.
- Emacs 31.0.90 ERT suite: 4/4 passed.
- Source and tests byte-compiled with warnings treated as errors.
- `package-lint` passed in an isolated package environment.
- Downstream GUI E2E completed eight clean startup phases using the installed
  VC package: a raw three-tab/three-window terminal layout, a
  restore-save-cold-restore placeholder cycle, repeated numeric tab switching,
  window-only Control-Tab switching, project-tab closure, and repeated cold
  restores.  Every restore emitted zero default-hook calls during frameset
  reconstruction and one stable call afterward, and no new native crash report
  was produced.
