### PR TITLE
Fix Magit commit buffers after a session restore

### DIFF
--- a/easysession.el
+++ b/easysession.el
@@ -1737,7 +1737,11 @@ accordingly, ensuring backward compatibility with legacy session files."
           (if (buffer-live-p original-buffer)
               (setq buffer (or (buffer-base-buffer original-buffer)
                                original-buffer))
-            (let ((new-buffer (let ((inhibit-message t))
+            (let ((new-buffer (let ((inhibit-message t)
+                                    (find-file-hook
+                                     (seq-difference
+                                      find-file-hook
+                                      easysession-exclude-from-find-file-hook)))
                                 (condition-case err
                                     (find-file-noselect buffer-path t)
                                   (error
@@ -2468,10 +2472,6 @@ loads the current session if set, or defaults to the \"main\" session."
                                     session-name)))
                     (when (file-exists-p file-name)
                       file-name)))
-                 (find-file-hook
-                  (seq-difference
-                   find-file-hook
-                   easysession-exclude-from-find-file-hook))
                  ;; This prevents `auto-insert-mode' from
                  ;; halting the background session load with
                  ;; interactive prompts (or silently

--- a/easysession.el
+++ b/easysession.el
@@ -1814,7 +1814,7 @@ If BUFFER is not a base buffer or has no associated path, return nil."
                     (buffer-file-name)))
             (uniquify-base-name (and (fboundp 'uniquify-buffer-base-name)
                                      (uniquify-buffer-base-name))))
-        (when path
+        (when (and path (not (bound-and-true-p with-editor-mode)))
           ;; File visiting buffer and base buffers (not carbon copies)
           `((buffer-name . ,(buffer-name))
             (uniquify-base-name . ,uniquify-base-name)


### PR DESCRIPTION
Fixes #69 along with a failure point that I found while looking into #69.

There are two commits here. 1db72184c910c9cd6805ec06f8e07e963f0382f7 is enough to fix #69, and 7b5270626454dcf7ba9bcc2f6a5aba59c9475b45 fixes another issue that I initially thought could be the reason for #69.

1db72184c910c9cd6805ec06f8e07e963f0382f7: `easysession-load` let-binds `find-file-hook` around the entire load, which includes load handlers. `easysession-magit` requires Magit from its restore function, which loads `git-commit.el` and adds `git-commit-setup-check-buffer` to the let-bound hook, so it is discarded when the binding unwinds. `global-git-commit-mode` stays enabled but inactive: commit buffers are visited without `git-commit-setup`, so `with-editor-mode` is never enabled, and thus `C-c C-c` is unbound. This is the reported bug in #69. It only triggers when Magit is loaded for the first time during restore (so it doesn't affect eager-loading configurations). The fix let-binds `find-file-hook` only around the `find-file-noselect` call that restores a buffer, so hooks added by packages loaded during the restore survive.

There are two side effects of this that I would like your opinion on: `easysession-exclude-from-find-file-hook` exclusions are now recalculated for each restored buffer instead of once per load, which undoes the optimization from 1.2.2, though the recalculation is negligible next to the file I/O. The exclusions also no longer apply to files opened by a `:restore` function, only to the buffers EasySession restores itself. This does not affect the extensions in this repository, since none of them visit files. Let me know if you would prefer changes here.

7b5270626454dcf7ba9bcc2f6a5aba59c9475b45: If a session is saved while Magit has a commit message buffer open, EasySession records `.git/COMMIT_EDITMSG` like any other file buffer, and loading the session later recreates a buffer visiting it, but by that point the `git commit` process it belonged to has exited. At the next commit, `server-visit-files` reuses that buffer instead of visiting the file Git just rewrote, so Emacs prompts to revert it. Accepting re-reads the file and the commit proceeds normally; declining leaves last session's message in place of the template Git just wrote, and since the buffer is unmodified nothing is written back, so Git sees only its own comment template and aborts the commit. The fix skips buffers with `with-editor-mode` when saving, which also covers rebase sequences and non-Git editors.